### PR TITLE
Feat: Jwt 관련  기능 마이그레이션 & 권한 AOP 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
 
 	//s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	//jwt
+	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 dependencyManagement {

--- a/src/main/java/com/catcher/common/GlobalExceptionHandlerFilter.java
+++ b/src/main/java/com/catcher/common/GlobalExceptionHandlerFilter.java
@@ -1,0 +1,39 @@
+package com.catcher.common;
+
+import com.catcher.common.exception.BaseException;
+import com.catcher.common.exception.BaseResponseStatus;
+import com.catcher.common.response.CommonResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.springframework.http.MediaType.*;
+
+@RequiredArgsConstructor
+public class GlobalExceptionHandlerFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (BaseException e) {
+            setErrorResponse(response, e);
+        }
+    }
+
+    public void setErrorResponse(HttpServletResponse response, BaseException e) throws IOException {
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType(APPLICATION_JSON_VALUE);
+
+        BaseResponseStatus status = e.getStatus();
+        CommonResponse<String> failure = CommonResponse.fail(status.getCode(), status.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(failure));
+    }
+}

--- a/src/main/java/com/catcher/common/exception/BaseResponseStatus.java
+++ b/src/main/java/com/catcher/common/exception/BaseResponseStatus.java
@@ -13,6 +13,9 @@ public enum BaseResponseStatus {
     // Common
     NO_ADDRESS_RESULT_FOR_QUERY(2000, "해당하는 요청에 대응되는 주소 검색 결과가 없습니다."),
     NO_LOCATION_RESULT(2001, "해당하는 요청에 대응되는 법정동 코드가 없습니다"),
+    INVALID_JWT(2002, "토큰 정보가 유효하지 않습니다."),
+    NO_ACCESS_AUTHORIZATION(2003, "접근 권한이 없습니다."),
+
 
     /**
      * 3000 : Response 오류

--- a/src/main/java/com/catcher/core/db/UserRepository.java
+++ b/src/main/java/com/catcher/core/db/UserRepository.java
@@ -1,0 +1,11 @@
+package com.catcher.core.db;
+
+import com.catcher.core.domain.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/com/catcher/core/domain/entity/User.java
+++ b/src/main/java/com/catcher/core/domain/entity/User.java
@@ -1,5 +1,6 @@
 package com.catcher.core.domain.entity;
 
+import com.catcher.core.domain.entity.enums.UserGender;
 import com.catcher.core.domain.entity.enums.UserProvider;
 import com.catcher.core.domain.entity.enums.UserRole;
 import jakarta.persistence.*;
@@ -38,10 +39,15 @@ public class User extends BaseTimeEntity {
     private String nickname;
 
     @Enumerated(value = EnumType.STRING)
+    private UserGender userGender;
+
+    @Enumerated(value = EnumType.STRING)
     private UserProvider userProvider;
 
     @Enumerated(value = EnumType.STRING)
     private UserRole userRole;
+
+    private ZonedDateTime phoneAuthentication;
 
     @Column(nullable = false)
     private ZonedDateTime userAgeTerm; // 필수 약관

--- a/src/main/java/com/catcher/core/domain/entity/enums/UserGender.java
+++ b/src/main/java/com/catcher/core/domain/entity/enums/UserGender.java
@@ -1,0 +1,5 @@
+package com.catcher.core.domain.entity.enums;
+
+public enum UserGender {
+    MALE, FEMALE,
+}

--- a/src/main/java/com/catcher/core/domain/entity/enums/UserRole.java
+++ b/src/main/java/com/catcher/core/domain/entity/enums/UserRole.java
@@ -4,11 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum UserRole {
-    USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+    // (1 << 0) : User Role, (1 << 1) Admin Role
+    USER("ROLE_USER", 0b0001), ADMIN("ROLE_ADMIN", 0b0011);
 
     private final String value;
+    private final int bitMask;
 
-    UserRole(String value) {
+    UserRole(String value, int bitMask) {
         this.value = value;
+        this.bitMask = bitMask;
     }
 }

--- a/src/main/java/com/catcher/datasource/user/UserJpaRepository.java
+++ b/src/main/java/com/catcher/datasource/user/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package com.catcher.datasource.user;
+
+import com.catcher.core.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/catcher/datasource/user/UserRepositoryImpl.java
+++ b/src/main/java/com/catcher/datasource/user/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.catcher.datasource.user;
+
+import com.catcher.core.db.UserRepository;
+import com.catcher.core.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findByUsername(String username) {
+        return userJpaRepository.findByUsername(username);
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/catcher/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/catcher/infrastructure/jwt/JwtTokenProvider.java
@@ -1,0 +1,51 @@
+package com.catcher.infrastructure.jwt;
+
+import com.catcher.common.exception.BaseException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.micrometer.common.util.StringUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import static com.catcher.common.exception.BaseResponseStatus.INVALID_JWT;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+    private final UserDetailsService userDetailsService;
+
+    public Authentication getAuthentication(String token) {
+        String userPrincipal = Jwts.parser().
+                setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userPrincipal);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            checkToken(token);
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            throw new BaseException(INVALID_JWT);
+        }
+    }
+
+    private void checkToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            throw new BaseException(INVALID_JWT);
+        }
+    }
+}

--- a/src/main/java/com/catcher/infrastructure/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/catcher/infrastructure/jwt/filter/JwtFilter.java
@@ -1,0 +1,42 @@
+package com.catcher.infrastructure.jwt.filter;
+
+import com.catcher.infrastructure.jwt.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = getAccessToken(request);
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION);
+
+        if (header != null && header.startsWith("Bearer ")) {
+            header = header.substring(7);
+        }
+        return header;
+    }
+}

--- a/src/main/java/com/catcher/resource/AuthTestController.java
+++ b/src/main/java/com/catcher/resource/AuthTestController.java
@@ -1,0 +1,29 @@
+package com.catcher.resource;
+
+import com.catcher.core.domain.entity.User;
+import com.catcher.core.domain.entity.enums.UserRole;
+import com.catcher.security.annotation.AuthorizationRequired;
+import com.catcher.security.annotation.CurrentUser;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/auth-test")
+public class AuthTestController {
+    // TODO : 해당 클래스는 삭제 예정
+    
+    @GetMapping("/no-auth")
+    public String noAuth() {
+        return "no-auth";
+    }
+
+    @GetMapping("/auth")
+    @AuthorizationRequired(value = UserRole.USER)
+    public String needAuth(@CurrentUser User user) {
+        log.info("nickname = {}, role = {}", user.getNickname(), user.getUserRole().name());
+        return "auth";
+    }
+}

--- a/src/main/java/com/catcher/security/CatcherUser.java
+++ b/src/main/java/com/catcher/security/CatcherUser.java
@@ -1,0 +1,56 @@
+package com.catcher.security;
+
+import com.catcher.core.domain.entity.User;
+import com.catcher.core.domain.entity.enums.UserRole;
+import lombok.Getter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+
+import static java.util.Collections.singleton;
+
+@Getter
+public class CatcherUser extends org.springframework.security.core.userdetails.User implements Authentication {
+    private User user;
+
+    public CatcherUser(User user) {
+        super(user.getUsername(), user.getPassword(), parseAuthority(user.getUserRole()));
+        this.user = user;
+    }
+
+    private static Collection<? extends GrantedAuthority> parseAuthority(UserRole userRole) {
+        return singleton(new SimpleGrantedAuthority(userRole.getValue()));
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.user;
+    }
+
+    @Override
+    public Object getDetails() {
+        return user.getUsername();
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return user.getPassword();
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/com/catcher/security/SecurityConfig.java
+++ b/src/main/java/com/catcher/security/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.catcher.security;
+
+import com.catcher.common.GlobalExceptionHandlerFilter;
+import com.catcher.infrastructure.jwt.JwtTokenProvider;
+import com.catcher.infrastructure.jwt.filter.JwtFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf((csrf) -> csrf.disable())
+                .cors((cors) -> cors.disable())
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new GlobalExceptionHandlerFilter(objectMapper), JwtFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/com/catcher/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/catcher/security/UserDetailsServiceImpl.java
@@ -1,0 +1,21 @@
+package com.catcher.security;
+
+import com.catcher.core.db.UserRepository;
+import com.catcher.core.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username).orElseThrow();
+        return new CatcherUser(user);
+    }
+}

--- a/src/main/java/com/catcher/security/annotation/AuthorizationRequired.java
+++ b/src/main/java/com/catcher/security/annotation/AuthorizationRequired.java
@@ -1,0 +1,13 @@
+package com.catcher.security.annotation;
+
+import com.catcher.core.domain.entity.enums.UserRole;
+
+import java.lang.annotation.*;
+
+@Inherited
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AuthorizationRequired {
+
+    UserRole[] value();
+}

--- a/src/main/java/com/catcher/security/annotation/CurrentUser.java
+++ b/src/main/java/com/catcher/security/annotation/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.catcher.security.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface CurrentUser {
+}

--- a/src/main/java/com/catcher/security/aop/AuthorizationAop.java
+++ b/src/main/java/com/catcher/security/aop/AuthorizationAop.java
@@ -1,0 +1,54 @@
+package com.catcher.security.aop;
+
+import com.catcher.common.exception.BaseException;
+import com.catcher.common.exception.BaseResponseStatus;
+import com.catcher.core.domain.entity.enums.UserRole;
+import com.catcher.security.CatcherUser;
+import com.catcher.security.annotation.AuthorizationRequired;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+@Aspect
+@Component
+public class AuthorizationAop {
+
+    @Before("@annotation(com.catcher.security.annotation.AuthorizationRequired)")
+    public void processCustom(JoinPoint joinPoint) {
+        AuthorizationRequired annotation = getAnnotation(joinPoint);
+
+        try {
+            UserRole currentUserRole = getCurrentUserRole();
+            UserRole[] userRoles = annotation.value();
+
+            checkUserRoles(userRoles, currentUserRole);
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.NO_ACCESS_AUTHORIZATION);
+        }
+    }
+
+    private void checkUserRoles(UserRole[] userRoles, UserRole role) {
+        Arrays.stream(userRoles)
+                .filter(userRole -> userRole.equals(role))
+                .findAny()
+                .orElseThrow();
+    }
+
+    private AuthorizationRequired getAnnotation(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        return method.getAnnotation(AuthorizationRequired.class);
+    }
+
+    private UserRole getCurrentUserRole() {
+        CatcherUser catcherUser = (CatcherUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return catcherUser.getUser().getUserRole();
+    }
+}

--- a/src/main/java/com/catcher/security/aop/AuthorizationAop.java
+++ b/src/main/java/com/catcher/security/aop/AuthorizationAop.java
@@ -27,17 +27,20 @@ public class AuthorizationAop {
             UserRole currentUserRole = getCurrentUserRole();
             UserRole[] userRoles = annotation.value();
 
-            checkUserRoles(userRoles, currentUserRole);
+            if (!checkUserRoles(userRoles, currentUserRole)) {
+                throw new RuntimeException();
+            }
         } catch (Exception e) {
             throw new BaseException(BaseResponseStatus.NO_ACCESS_AUTHORIZATION);
         }
     }
 
-    private void checkUserRoles(UserRole[] userRoles, UserRole role) {
-        Arrays.stream(userRoles)
-                .filter(userRole -> userRole.equals(role))
-                .findAny()
-                .orElseThrow();
+    private boolean checkUserRoles(UserRole[] userRoles, UserRole role) {
+        for (UserRole userRole : userRoles) {
+            if ((userRole.getBitMask() & role.getBitMask()) > 0)
+                return true;
+        }
+        return false;
     }
 
     private AuthorizationRequired getAnnotation(JoinPoint joinPoint) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.profiles.active=test
 # TODO : jwt secret은 실제 배포할 때 변경하고, kms 적용 필요 (core-service도 같이)
 spring.jwt.secret=YWxsLXRpbWUtY2F0Y2hlci1qd3Qtc2VjcmV0LWNvbmZpZ3VyYXRpb24tZGV2bC1zb3VyY2UtY29kZQo=
+
+server.servlet.encoding.force-response=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.profiles.active=test
+# TODO : jwt secret은 실제 배포할 때 변경하고, kms 적용 필요 (core-service도 같이)
+spring.jwt.secret=YWxsLXRpbWUtY2F0Y2hlci1qd3Qtc2VjcmV0LWNvbmZpZ3VyYXRpb24tZGV2bC1zb3VyY2UtY29kZQo=


### PR DESCRIPTION
작업 내용
- core-service에 있는 Jwt관련 일부분을 catcher-service로 마이그레이션 하였습니다.
- Aop를 활용해 권한 엔드포인트 기능을 추가하였습니다.

Aop를 활용한 권한 제어 예제는 아래 사진을 참고해주시면 될 것 같습니다. (AuthorizationRequired 어노테이션에 접근 가능한 UserRole을 설정해주시면 됩니다.)
해당 클래스는 다음 pr에 제가 삭제할 예정입니다.
<img width="800" alt="image" src="https://github.com/Project-Catcher/catcher-service/assets/108642272/7d43da62-6a50-4cb2-9770-3d017de81b63">
