### PR TITLE
Refactor: 내 일정 - 모집 중 조건 수정

### DIFF
--- a/src/main/java/com/catcher/core/database/ScheduleRepository.java
+++ b/src/main/java/com/catcher/core/database/ScheduleRepository.java
@@ -21,6 +21,8 @@ public interface ScheduleRepository {
 
     List<Schedule> openScheduleList();
 
+    List<Schedule> myOpenScheduleList(Long userId);    // 내 일정 -> 모집중
+
     List<Schedule> appliedScheduleList(Long userId);
 
     void saveAll(List<Schedule> scheduleList);

--- a/src/main/java/com/catcher/core/service/ScheduleService.java
+++ b/src/main/java/com/catcher/core/service/ScheduleService.java
@@ -214,7 +214,7 @@ public class ScheduleService {
         return new MyListResponse(
                 scheduleRepository.upcomingScheduleList(userId),    //다가오는 일정
                 scheduleRepository.draftScheduleList(userId),       //작성중인 일정
-                scheduleRepository.openScheduleList(),              //모집 중
+                scheduleRepository.myOpenScheduleList(userId),      //모집 중
                 scheduleRepository.appliedScheduleList(userId)      //참여 신청
         );
     }

--- a/src/main/java/com/catcher/datasource/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/catcher/datasource/ScheduleRepositoryImpl.java
@@ -142,7 +142,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
 
     @Override
     public List<Schedule> myOpenScheduleList(Long userId) {
-        return scheduleJpaRepository.findSchedulesByUserIdAndTodayBetweenParticipateDates(userId)
+        return scheduleJpaRepository.findSchedulesByUserIdAndTodayBetweenParticipateDatesAndStatus(userId, ScheduleStatus.NORMAL)
                 .stream()
                 .limit(7)
                 .collect(Collectors.toList());

--- a/src/main/java/com/catcher/datasource/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/catcher/datasource/ScheduleRepositoryImpl.java
@@ -109,6 +109,9 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 남은 일정중 모집중인 일정에 대한 조회 -> 현재 사용중 X
+     */
     @Override
     public List<Schedule> openScheduleList() {
         List<Schedule> scheduleList = scheduleJpaRepository.findByScheduleStatusAndParticipationPeriod(ScheduleStatus.NORMAL, LocalDateTime.now());
@@ -136,6 +139,15 @@ public class ScheduleRepositoryImpl implements ScheduleRepository {
                 .limit(7)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<Schedule> myOpenScheduleList(Long userId) {
+        return scheduleJpaRepository.findSchedulesByUserIdAndTodayBetweenParticipateDates(userId)
+                .stream()
+                .limit(7)
+                .collect(Collectors.toList());
+    }
+
 
     @Override
     public List<Schedule> appliedScheduleList(Long userId) {

--- a/src/main/java/com/catcher/datasource/repository/ScheduleJpaRepository.java
+++ b/src/main/java/com/catcher/datasource/repository/ScheduleJpaRepository.java
@@ -39,8 +39,11 @@ public interface ScheduleJpaRepository extends JpaRepository<Schedule, Long>, Jp
             "JOIN FETCH s.user " +
             "WHERE s.user.id = :userId " +
             "AND CURRENT_TIMESTAMP BETWEEN s.participateStartAt AND s.participateEndAt " +
+            "AND s.scheduleStatus = :scheduleStatus " +
+            "AND CURRENT_TIMESTAMP <= s.startAt " +
             "ORDER BY s.startAt ASC")
-    List<Schedule> findSchedulesByUserIdAndTodayBetweenParticipateDates(
-            @Param("userId") Long userId
+    List<Schedule> findSchedulesByUserIdAndTodayBetweenParticipateDatesAndStatus(
+            @Param("userId") Long userId,
+            @Param("scheduleStatus") ScheduleStatus scheduleStatus
     );
 }

--- a/src/main/java/com/catcher/datasource/repository/ScheduleJpaRepository.java
+++ b/src/main/java/com/catcher/datasource/repository/ScheduleJpaRepository.java
@@ -34,4 +34,13 @@ public interface ScheduleJpaRepository extends JpaRepository<Schedule, Long>, Jp
     int updateScheduleToDeleted(@Param("userId") Long userId, @Param("id") Long id);
 
     Optional<Schedule> findByIdAndScheduleStatus(Long scheduleId, ScheduleStatus scheduleStatus);
+
+    @Query("SELECT s FROM Schedule s " +
+            "JOIN FETCH s.user " +
+            "WHERE s.user.id = :userId " +
+            "AND CURRENT_TIMESTAMP BETWEEN s.participateStartAt AND s.participateEndAt " +
+            "ORDER BY s.startAt ASC")
+    List<Schedule> findSchedulesByUserIdAndTodayBetweenParticipateDates(
+            @Param("userId") Long userId
+    );
 }

--- a/src/test/java/com/catcher/datasource/ScheduleRepositoryImplTest.java
+++ b/src/test/java/com/catcher/datasource/ScheduleRepositoryImplTest.java
@@ -421,6 +421,19 @@ public class ScheduleRepositoryImplTest {
         );
     }
 
+    @DisplayName("모집중인 내 일정이 없는 경우, 빈 리스트를 반환한다")
+    @Test
+    void return_empty_list_if_no_schedule_created_by_user(){
+        //given
+        setShouldSkipSetup(true);
+
+        //when
+        List<Schedule> myOpenedList = scheduleRepository.myOpenScheduleList(userList.get(0).getId());
+
+        //then
+        assertThat(myOpenedList).isEmpty();
+    }
+
     private void setShouldSkipSetup(boolean shouldSkipSetup) {
         this.shouldSkipSetup = shouldSkipSetup;
     }

--- a/src/test/java/com/catcher/datasource/ScheduleRepositoryImplTest.java
+++ b/src/test/java/com/catcher/datasource/ScheduleRepositoryImplTest.java
@@ -78,7 +78,8 @@ public class ScheduleRepositoryImplTest {
                         user,
                         statusValues[random.nextInt(statusValues.length)],
                         LocalDateTime.now().plus(5, ChronoUnit.DAYS),
-                        LocalDateTime.now().plus(7, ChronoUnit.DAYS)
+                        LocalDateTime.now().plus(7, ChronoUnit.DAYS),
+                        null
                 );
 
                 scheduleList.add(schedule);
@@ -135,7 +136,8 @@ public class ScheduleRepositoryImplTest {
                     userList.get(0),
                     ScheduleStatus.DRAFT,
                     LocalDateTime.now(),
-                    LocalDateTime.now()
+                    LocalDateTime.now(),
+                    null
             );
             draftScheduleList.add(schedule);
         }
@@ -143,7 +145,8 @@ public class ScheduleRepositoryImplTest {
                 userList.get(0),
                 ScheduleStatus.DRAFT,
                 LocalDateTime.now(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                null
         );
         draftScheduleList.add(currentSchedule);
         scheduleRepository.saveAll(draftScheduleList);
@@ -183,7 +186,8 @@ public class ScheduleRepositoryImplTest {
                     userList.get(0),
                     ScheduleStatus.NORMAL,
                     LocalDateTime.now(),
-                    LocalDateTime.now()
+                    LocalDateTime.now(),
+                    null
             );
             normalScheduleList.add(schedule);
         }
@@ -215,7 +219,8 @@ public class ScheduleRepositoryImplTest {
                     userList.get(0),
                     ScheduleStatus.NORMAL,
                     LocalDateTime.now().minusDays(1L),
-                    LocalDateTime.now().plusDays(1L)
+                    LocalDateTime.now().plusDays(1L),
+                    null
             );
             normalScheduleList.add(schedule);
         }
@@ -253,7 +258,8 @@ public class ScheduleRepositoryImplTest {
                 userList.get(0),
                 ScheduleStatus.NORMAL,
                 LocalDateTime.now().minusDays(1L),
-                LocalDateTime.now().plusDays(1L)
+                LocalDateTime.now().plusDays(1L),
+                null
         );
         scheduleRepository.save(normalSchedule);
 
@@ -282,7 +288,8 @@ public class ScheduleRepositoryImplTest {
                 userList.get(0),
                 ScheduleStatus.NORMAL,
                 LocalDateTime.now().minusDays(1L),
-                LocalDateTime.now().plusDays(1L)
+                LocalDateTime.now().plusDays(1L),
+                null
         );
         scheduleRepository.save(normalSchedule);
 
@@ -337,7 +344,8 @@ public class ScheduleRepositoryImplTest {
                     userList.get(0),
                     ScheduleStatus.NORMAL,
                     LocalDateTime.now(),
-                    LocalDateTime.now()
+                    LocalDateTime.now(),
+                    null
             );
             normalScheduleList.add(schedule);
         }
@@ -383,7 +391,8 @@ public class ScheduleRepositoryImplTest {
                 userList.get(0),
                 ScheduleStatus.DRAFT,
                 LocalDateTime.now(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                null
         );
         scheduleRepository.save(draftSchedule);
 
@@ -408,7 +417,8 @@ public class ScheduleRepositoryImplTest {
                 userList.get(0),
                 ScheduleStatus.DRAFT,
                 LocalDateTime.now(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                null
         );
         scheduleRepository.save(draftSchedule);
         flushAndClearPersistence();
@@ -434,6 +444,47 @@ public class ScheduleRepositoryImplTest {
         assertThat(myOpenedList).isEmpty();
     }
 
+    @DisplayName("정상 모집중인 내 일정이 여러개인 경우, 최대 7개만 반환한다")
+    @Test
+    void return_less_than_8_schedule_if_user_created_more_than_7_schedules_having_normal_state(){
+        //given
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        List<Schedule> newScheduleList = new ArrayList<>();
+        for(int i=0;i<10;i++){
+            Schedule schedule = generateSchedule(
+                    userList.get(0),
+                    ScheduleStatus.NORMAL,
+                    LocalDateTime.now().plusDays(5),
+                    LocalDateTime.now().plusDays(7),
+                    LocalDateTime.now().minusDays(5)
+            );
+            newScheduleList.add(schedule);
+        }
+        Schedule earlySchedule = generateSchedule(
+                userList.get(0),
+                ScheduleStatus.NORMAL,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(7),
+                LocalDateTime.now().minusDays(5)
+        );
+        newScheduleList.add(earlySchedule);
+        scheduleRepository.saveAll(newScheduleList);
+        flushAndClearPersistence();
+
+        //when
+        List<Schedule> myOpenedList = scheduleRepository.myOpenScheduleList(userList.get(0).getId());
+
+        //then
+        assertThat(myOpenedList).doesNotContain(earlySchedule);
+        assertThat(myOpenedList.size()).isLessThanOrEqualTo(7);
+
+        for(Schedule s : myOpenedList){
+            assertThat(s.getScheduleStatus()).isEqualTo(ScheduleStatus.NORMAL);
+            assertThat(s.getParticipateStartAt()).isBeforeOrEqualTo(currentDateTime);
+            assertThat(s.getParticipateEndAt()).isAfterOrEqualTo(currentDateTime);
+        }
+    }
+
     private void setShouldSkipSetup(boolean shouldSkipSetup) {
         this.shouldSkipSetup = shouldSkipSetup;
     }
@@ -446,7 +497,9 @@ public class ScheduleRepositoryImplTest {
                 .build();
     }
 
-    private Schedule generateSchedule(User user, ScheduleStatus scheduleStatus, LocalDateTime startAt, LocalDateTime endAt) {
+    private Schedule generateSchedule(User user, ScheduleStatus scheduleStatus, LocalDateTime startAt, LocalDateTime endAt, LocalDateTime participateStartAt) {
+        participateStartAt = participateStartAt == null ? startAt : participateStartAt;
+
         return Schedule.builder()
                 .user(user)
                 .location(location)
@@ -457,7 +510,7 @@ public class ScheduleRepositoryImplTest {
                 .startAt(startAt)
                 .endAt(endAt)
                 .viewCount(1L)
-                .participateStartAt(startAt)
+                .participateStartAt(participateStartAt)
                 .participateEndAt(endAt)
                 .thumbnailUrl("https://thumbnail-img-s3.s3.ap-northeast-2.amazonaws.com/dog.jpg")
                 .build();


### PR DESCRIPTION
### SWIT
[티켓](https://app.swit.io/share-route?route_type=project&route_variables=23091405520180SZFQIM%2C23091405572194IM56Q6%2C23122504023551U9WSLN%2C)

### 변경된 부분 - 피그마 기준
![image](https://github.com/Project-Catcher/catcher-service/assets/32122076/391f3ac7-5042-46b5-a06c-5cc202394fc9)

### 변경 사항
[AS-IS]
함수명: scheduleRepository.openScheduleList()
기능: 남은 일정중 모집중인 일정에 대한 조회(작성자가 로그인한 사용자랑 상관없이 모두 가져옴)

TO-BE
함수명: scheduleRepository.myOpenScheduleList(userId)
기능: 내가 작성한 일정 중 모집중인 일정에 대한 조회
조건:
- 아직 시작하지 않은 일정
- 오늘 기준, 모집 기간 사이에 존재
- 내가 올린 모집 일정
- 인원 가득 찼어도 상관X